### PR TITLE
修复 JEI 兼容问题

### DIFF
--- a/src/main/java/com/fiercemanul/blackholestorage/compat/ControlPanelRecipeHandler.java
+++ b/src/main/java/com/fiercemanul/blackholestorage/compat/ControlPanelRecipeHandler.java
@@ -48,6 +48,11 @@ public class ControlPanelRecipeHandler<R> implements IRecipeTransferHandler<Cont
     }
 
     @Override
+    public @NotNull Class<R> getRecipeClass() {
+        return (Class<R>) CraftingRecipe.class;
+    }
+
+    @Override
     public @NotNull Optional<MenuType<ControlPanelMenu>> getMenuType() {
         return Optional.of(BlackHoleStorage.CONTROL_PANEL_MENU.get());
     }


### PR DESCRIPTION
修复 https://github.com/FierceManul/BlackHoleStorage/issues/2

更新 JEI 版本但发现问题依然存在，看了下是  `ControlPanelRecipeHandler` 未覆写 `getRecipeClass()`

对应原日志 ` Cannot invoke "java.lang.Class.isAssignableFrom(java.lang.Class)" because the return value of "mezz.jei.api.recipe.transfer.IRecipeTransferHandler.getRecipeClass()" is null` 

经测试可以正常从黑洞物品面板打开 JEI 了

