### PR TITLE
修复 #3 面板 E 键意外关闭问题

### DIFF
--- a/src/main/java/com/fiercemanul/blackholestorage/gui/ChannelSelectScreen.java
+++ b/src/main/java/com/fiercemanul/blackholestorage/gui/ChannelSelectScreen.java
@@ -169,6 +169,9 @@ public class ChannelSelectScreen extends BaseScreen<ChannelSelectMenu> {
 
     @Override
     public boolean keyPressed(int pKeyCode, int pScanCode, int pModifiers) {
+        if (nameBox.isFocused() || searchBox.isFocused()) {
+            if (pKeyCode >= InputConstants.KEY_0 && pKeyCode <= InputConstants.KEY_Z) return true;
+        }
         if (pKeyCode == InputConstants.KEY_LSHIFT) lShifting = true;
         return super.keyPressed(pKeyCode, pScanCode, pModifiers);
     }


### PR DESCRIPTION

在 ChannelSelectScreen 增加了 focus 时的拦截

![X}P)_BV 2Y)5`)IT9D47 4R](https://github.com/FierceManul/BlackHoleStorage/assets/36336351/5fa2962a-22dd-42d0-ad32-a8b72d7b6b97)

测试正常啦